### PR TITLE
chore: update golangci-lint and migrate to lefthook

### DIFF
--- a/apps/api/.golangci.yml
+++ b/apps/api/.golangci.yml
@@ -1,7 +1,12 @@
-linters:
-  disable-all: true
+version: "2"
+
+formatters:
   enable:
     - goimports
+
+linters:
+  default: none
+  enable:
     - revive
     - govet
     - errcheck
@@ -11,41 +16,43 @@ linters:
     - prealloc
     - gosec
 
-issues:
-  exclude-use-default: false
+  settings:
+    govet:
+      enable:
+        - shadow
 
-linters-settings:
-  govet:
-    check-shadowing: true
+    errcheck:
+      exclude-functions:
+        - fmt.*
+        - (io.Closer).Close
 
-  errcheck:
-      ignore: "fmt:.*,Close"
+    revive:
+      # Use recommended configuration
+      # @see https://github.com/mgechev/revive#recommended-configuration
+      rules:
+        - name: blank-imports
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: dot-imports
+        - name: error-return
+        - name: error-strings
+        - name: error-naming
+        - name: exported
+        - name: if-return
+        - name: increment-decrement
+        - name: var-naming
+        - name: var-declaration
+        - name: package-comments
+        - name: range
+        - name: receiver-naming
+        - name: time-naming
+        - name: unexported-return
+        - name: indent-error-flow
+        - name: errorf
+        - name: empty-block
+        - name: superfluous-else
+        - name: unreachable-code
+        - name: redefines-builtin-id
 
-  revive:
-    # Use recommended configuration
-    # @see https://github.com/mgechev/revive#recommended-configuration
-    rules:
-      - name: blank-imports
-      - name: context-as-argument
-      - name: context-keys-type
-      - name: dot-imports
-      - name: error-return
-      - name: error-strings
-      - name: error-naming
-      - name: exported
-      - name: if-return
-      - name: increment-decrement
-      - name: var-naming
-      - name: var-declaration
-      - name: package-comments
-      - name: range
-      - name: receiver-naming
-      - name: time-naming
-      - name: unexported-return
-      - name: indent-error-flow
-      - name: errorf
-      - name: empty-block
-      - name: superfluous-else
-#      - name: unused-parameter
-      - name: unreachable-code
-      - name: redefines-builtin-id
+  exclusions:
+    generated: lax

--- a/apps/api/.pre-commit-config.yaml
+++ b/apps/api/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.56.2
+    rev: v2.12.2
     hooks:
       - id: golangci-lint
 

--- a/apps/api/.pre-commit-config.yaml
+++ b/apps/api/.pre-commit-config.yaml
@@ -1,6 +1,0 @@
-repos:
-  - repo: https://github.com/golangci/golangci-lint
-    rev: v2.12.2
-    hooks:
-      - id: golangci-lint
-

--- a/apps/api/Makefile
+++ b/apps/api/Makefile
@@ -4,7 +4,7 @@ install:
 	brew install pre-commit
 	pre-commit --version
 	pre-commit install
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.2
+	brew install golangci-lint
 	go install golang.org/x/tools/cmd/goimports@latest
 	go install github.com/cosmtrek/air@v1.51.0
 

--- a/apps/api/Makefile
+++ b/apps/api/Makefile
@@ -1,9 +1,6 @@
 # Set up tools.
 install:
 	brew install yq
-	brew install pre-commit
-	pre-commit --version
-	pre-commit install
 	brew install golangci-lint
 	go install golang.org/x/tools/cmd/goimports@latest
 	go install github.com/cosmtrek/air@v1.51.0

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -17,3 +17,9 @@ pre-commit:
       root: apps/nextjs/
       glob: "*.{ts,tsx}"
       run: npx tsc
+    api/lint:
+      tags: api
+      root: apps/api/
+      glob: "*.go"
+      stage_fixed: true
+      run: golangci-lint run {staged_files}


### PR DESCRIPTION
## Summary

This PR modernizes the Go tooling setup by updating golangci-lint and migrating from pre-commit to lefthook for git hook management. The changes also include cleanup of unused code and files across the repository.

### Main Changes

**Tooling Updates:**
- Upgraded golangci-lint to v2.12.2 with improved configuration
- Replaced pre-commit with lefthook for git hooks (simpler setup, aligns with project standards)
- Switched golangci-lint installation from Go-based to Homebrew

**Code Cleanup:**
- Removed unused token utilities (`apps/api/pkg/util/token/token.go`)
- Removed unused Firebase auth client-side utilities (token handling migrated to server-side)
- Removed unused key resources components and assets
- Removed unused key binding and prosemirror plugin files

**Configuration:**
- Updated `.golangci.yml` with better linter rules and formatters
- Updated `Makefile` to reflect new tooling
- Added `lefthook.yml` configuration

## Related Issues

N/A

## Testing

- Verified golangci-lint runs successfully with new configuration
- Verified lefthook hooks execute properly
- Build and tests pass