### PR TITLE
fix: simplify navigation items in Portfolios and Goals to fix router error

### DIFF
--- a/apps/nextjs/src/components/layout/navigation/main-nav/goals/goals.tsx
+++ b/apps/nextjs/src/components/layout/navigation/main-nav/goals/goals.tsx
@@ -1,20 +1,16 @@
-import { usePathname } from 'next/navigation';
 import { memo, useMemo } from 'react';
-import { ROUTE_GOALS } from '@/router';
 import { NavListItem } from '../../nav-list-item';
 import type { NavListItem as TNavListItem } from '../../type';
 
 export const Goals = memo(function Goals() {
-  const pathname = usePathname();
-
   const item = useMemo<TNavListItem>(
     () => ({
       name: 'Goals',
-      href: ROUTE_GOALS.href.pathname(),
+      href: '/',
       icon: 'rocket',
-      isCurrentRoute: () => pathname === ROUTE_GOALS.href.pathname(),
+      isCurrentRoute: () => false,
     }),
-    [pathname],
+    [],
   );
 
   return <NavListItem item={item} disabled />;

--- a/apps/nextjs/src/components/layout/navigation/main-nav/portfolios/portfolios.tsx
+++ b/apps/nextjs/src/components/layout/navigation/main-nav/portfolios/portfolios.tsx
@@ -1,20 +1,16 @@
-import { usePathname } from 'next/navigation';
 import { memo, useMemo } from 'react';
-import { ROUTE_PORTFOLIOS } from '@/router';
 import { NavListItem } from '../../nav-list-item';
 import type { NavListItem as TNavListItem } from '../../type';
 
 export const Portfolios = memo(function Portfolios() {
-  const pathname = usePathname();
-
   const item = useMemo<TNavListItem>(
     () => ({
       name: 'Portfolios',
-      href: ROUTE_PORTFOLIOS.href.pathname(),
+      href: '/',
       icon: 'barChart',
-      isCurrentRoute: () => pathname === ROUTE_PORTFOLIOS.href.pathname(),
+      isCurrentRoute: () => false,
     }),
-    [pathname],
+    [],
   );
 
   return <NavListItem item={item} disabled />;


### PR DESCRIPTION
## Summary

This PR simplifies the navigation items for Portfolios and Goals components by removing unused router dependencies. Since both components are currently disabled (rendered with `disabled` prop), the routing logic and `usePathname` hook were unnecessary and potentially causing router errors.

### Changes:
- Removed `usePathname` hook from both `Goals` and `Portfolios` components
- Removed `ROUTE_GOALS` and `ROUTE_PORTFOLIOS` imports
- Simplified `href` to use a placeholder `/` since navigation is disabled
- Simplified `isCurrentRoute` to always return `false` since these routes are not active
- Removed unnecessary `pathname` dependency from `useMemo`

## Related Issues

N/A

## Testing

- Verified the navigation sidebar renders correctly with disabled Portfolios and Goals items
- No router errors occur when navigating through the app
