### PR TITLE
chore: update golangci-lint configuration

### DIFF
--- a/apps/api/.golangci.yml
+++ b/apps/api/.golangci.yml
@@ -1,10 +1,17 @@
 version: "2"
 
+run:
+  timeout: 5m
+  concurrency: 0
+  go: '1.25'
+  modules-download-mode: readonly
+  allow-parallel-runners: true
+
 formatters:
   enable:
     - goimports
   exclusions:
-    generated: lax
+    generated: strict
 
 linters:
   default: none
@@ -43,7 +50,6 @@ linters:
         - name: increment-decrement
         - name: var-naming
         - name: var-declaration
-#        - name: package-comments
         - name: range
         - name: receiver-naming
         - name: time-naming
@@ -56,7 +62,7 @@ linters:
         - name: redefines-builtin-id
 
   exclusions:
-    generated: lax
+    generated: strict
     rules:
       - linters:
           - errcheck


### PR DESCRIPTION
## Summary

Update golangci-lint configuration for improved linting strictness and performance.

### Changes

- **Added run configuration section**:
  - Set timeout to 5 minutes for longer analysis
  - Disabled concurrency limit (`concurrency: 0`) for maximum parallelism
  - Specified Go version as 1.25
  - Set modules download mode to `readonly` for reproducibility
  - Enabled `allow-parallel-runners` for CI optimization

- **Increased strictness for generated code**:
  - Changed `generated: lax` to `generated: strict` in both formatters and linters exclusions
  - This ensures generated code also adheres to linting standards

- **Cleaned up revive linter rules**:
  - Removed commented-out `package-comments` rule

## Related Issues

N/A

## Testing

- Verified golangci-lint configuration syntax is valid
- Configuration changes are backward-compatible with existing codebase