### PR TITLE
feat: implement Automatic Persisted Queries (APQ) for Apollo Client

### DIFF
--- a/apps/api/pkg/infrastructure/router/router.go
+++ b/apps/api/pkg/infrastructure/router/router.go
@@ -58,9 +58,12 @@ func New(srv *handler.Server, ctrl controller.Controller, options Options) *echo
 	}
 
 	{
-		g.POST(graphQLPath, echo.WrapHandler(srv), rm.Auth(rm.AuthOptions{
+		graphQLHandler := echo.WrapHandler(srv)
+		authMiddleware := rm.Auth(rm.AuthOptions{
 			Skip: !options.Auth,
-		}))
+		})
+		g.POST(graphQLPath, graphQLHandler, authMiddleware)
+		g.GET(graphQLPath, graphQLHandler, authMiddleware)
 
 		g.POST(graphQLPlaygroundPath, echo.WrapHandler(srv))
 

--- a/apps/nextjs/package.json
+++ b/apps/nextjs/package.json
@@ -37,6 +37,7 @@
     "chakra:typegen": "npx @chakra-ui/cli typegen src/lib/chakra-ui/theme.ts"
   },
   "dependencies": {
+    "crypto-hash": "4.0.1",
     "@apollo/client": "4.2.7",
     "@chakra-ui/react": "3.36.1",
     "@emoji-mart/data": "1.2.1",

--- a/apps/nextjs/src/lib/apollo/create-link.ts
+++ b/apps/nextjs/src/lib/apollo/create-link.ts
@@ -4,12 +4,21 @@ import { createErrorLink } from './create-error-link';
 import { type CreateHttpProps, createHttpLink } from './create-http-link';
 import { createPersistedQueryLink } from './create-persisted-query-link';
 
-export type CreateLinkProps = CreateHttpProps;
+export type CreateLinkProps = CreateHttpProps & {
+  disablePersistedQueries?: boolean;
+};
+
 export const createLink = (props: CreateLinkProps) => {
-  return ApolloLink.from([
+  const links: ApolloLink[] = [
     new RemoveTypenameFromVariablesLink(),
     createErrorLink(),
-    createPersistedQueryLink(),
-    createHttpLink(props),
-  ]);
+  ];
+
+  if (!props.disablePersistedQueries) {
+    links.push(createPersistedQueryLink());
+  }
+
+  links.push(createHttpLink(props));
+
+  return ApolloLink.from(links);
 };

--- a/apps/nextjs/src/lib/apollo/create-link.ts
+++ b/apps/nextjs/src/lib/apollo/create-link.ts
@@ -5,7 +5,7 @@ import { type CreateHttpProps, createHttpLink } from './create-http-link';
 import { createPersistedQueryLink } from './create-persisted-query-link';
 
 export type CreateLinkProps = CreateHttpProps & {
-  disablePersistedQueries?: boolean;
+  enablePersistedQueries?: boolean;
 };
 
 export const createLink = (props: CreateLinkProps) => {
@@ -14,7 +14,8 @@ export const createLink = (props: CreateLinkProps) => {
     createErrorLink(),
   ];
 
-  if (!props.disablePersistedQueries) {
+  const enablePersistedQueries = props.enablePersistedQueries ?? true;
+  if (enablePersistedQueries) {
     links.push(createPersistedQueryLink());
   }
 

--- a/apps/nextjs/src/lib/apollo/create-link.ts
+++ b/apps/nextjs/src/lib/apollo/create-link.ts
@@ -2,12 +2,14 @@ import { ApolloLink } from '@apollo/client/core';
 import { RemoveTypenameFromVariablesLink } from '@apollo/client/link/remove-typename';
 import { createErrorLink } from './create-error-link';
 import { type CreateHttpProps, createHttpLink } from './create-http-link';
+import { createPersistedQueryLink } from './create-persisted-query-link';
 
 export type CreateLinkProps = CreateHttpProps;
 export const createLink = (props: CreateLinkProps) => {
   return ApolloLink.from([
     new RemoveTypenameFromVariablesLink(),
     createErrorLink(),
+    createPersistedQueryLink(),
     createHttpLink(props),
   ]);
 };

--- a/apps/nextjs/src/lib/apollo/create-persisted-query-link.ts
+++ b/apps/nextjs/src/lib/apollo/create-persisted-query-link.ts
@@ -4,5 +4,6 @@ import { sha256 } from 'crypto-hash';
 export const createPersistedQueryLink = () => {
   return new PersistedQueryLink({
     sha256,
+    useGETForHashedQueries: true,
   });
 };

--- a/apps/nextjs/src/lib/apollo/create-persisted-query-link.ts
+++ b/apps/nextjs/src/lib/apollo/create-persisted-query-link.ts
@@ -1,0 +1,13 @@
+import { PersistedQueryLink } from '@apollo/client/link/persisted-queries';
+
+export const createPersistedQueryLink = () => {
+  return new PersistedQueryLink({
+    sha256: async (queryString: string): Promise<string> => {
+      const encoder = new TextEncoder();
+      const data = encoder.encode(queryString);
+      const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+      const hashArray = Array.from(new Uint8Array(hashBuffer));
+      return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
+    },
+  });
+};

--- a/apps/nextjs/src/lib/apollo/create-persisted-query-link.ts
+++ b/apps/nextjs/src/lib/apollo/create-persisted-query-link.ts
@@ -1,13 +1,8 @@
 import { PersistedQueryLink } from '@apollo/client/link/persisted-queries';
+import { sha256 } from 'crypto-hash';
 
 export const createPersistedQueryLink = () => {
   return new PersistedQueryLink({
-    sha256: async (queryString: string): Promise<string> => {
-      const encoder = new TextEncoder();
-      const data = encoder.encode(queryString);
-      const hashBuffer = await crypto.subtle.digest('SHA-256', data);
-      const hashArray = Array.from(new Uint8Array(hashBuffer));
-      return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
-    },
+    sha256,
   });
 };

--- a/apps/nextjs/src/storybook/provider.tsx
+++ b/apps/nextjs/src/storybook/provider.tsx
@@ -31,7 +31,7 @@ export const Provider = (props: PropsWithChildren) => {
 const ApolloProvider = (props: PropsWithChildren) => {
   const client = useMemo(
     () =>
-      createApolloClient({ idToken: 'token', disablePersistedQueries: true }),
+      createApolloClient({ idToken: 'token', enablePersistedQueries: false }),
     [],
   );
 

--- a/apps/nextjs/src/storybook/provider.tsx
+++ b/apps/nextjs/src/storybook/provider.tsx
@@ -29,7 +29,11 @@ export const Provider = (props: PropsWithChildren) => {
 };
 
 const ApolloProvider = (props: PropsWithChildren) => {
-  const client = useMemo(() => createApolloClient({ idToken: 'token' }), []);
+  const client = useMemo(
+    () =>
+      createApolloClient({ idToken: 'token', disablePersistedQueries: true }),
+    [],
+  );
 
   return (
     <ApolloProviderLibs client={client}>{props.children}</ApolloProviderLibs>

--- a/apps/nextjs/src/test-utils/provider.tsx
+++ b/apps/nextjs/src/test-utils/provider.tsx
@@ -23,7 +23,10 @@ export const Provider: React.FCWithChildren = (props) => {
 };
 
 function ApolloProvider({ children }: PropsWithChildren) {
-  const client = useMemo(() => createApolloClient({ idToken: '' }), []);
+  const client = useMemo(
+    () => createApolloClient({ idToken: '', disablePersistedQueries: true }),
+    [],
+  );
 
   return <ApolloProviderLibs client={client}>{children}</ApolloProviderLibs>;
 }

--- a/apps/nextjs/src/test-utils/provider.tsx
+++ b/apps/nextjs/src/test-utils/provider.tsx
@@ -24,7 +24,7 @@ export const Provider: React.FCWithChildren = (props) => {
 
 function ApolloProvider({ children }: PropsWithChildren) {
   const client = useMemo(
-    () => createApolloClient({ idToken: '', disablePersistedQueries: true }),
+    () => createApolloClient({ idToken: '', enablePersistedQueries: false }),
     [],
   );
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,6 +58,9 @@ importers:
       '@react-hook/passive-layout-effect':
         specifier: 1.2.1
         version: 1.2.1(react@19.2.8)
+      crypto-hash:
+        specifier: 4.0.1
+        version: 4.0.1
       date-fns:
         specifier: 4.4.0
         version: 4.4.0
@@ -3654,6 +3657,10 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  crypto-hash@4.0.1:
+    resolution: {integrity: sha512-4u4yl+8C+75Xedf1uMA0J/TTYAqJ54XdyBc1RV3UjCkU2wQjFMsB5ScjRDh3oo21zAwSprcVEDolaGDT8z5G6g==}
+    engines: {node: '>=20'}
 
   css-box-model@1.2.1:
     resolution: {integrity: sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==}
@@ -10109,6 +10116,8 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  crypto-hash@4.0.1: {}
 
   css-box-model@1.2.1:
     dependencies:


### PR DESCRIPTION
## Summary

Implement Automatic Persisted Queries (APQ) to reduce GraphQL request payload size and improve caching.

### Changes

**Frontend (Apollo Client)**
- Add `create-persisted-query-link.ts` that creates a PersistedQueryLink using `crypto-hash` for SHA-256 hashing
- Enable `useGETForHashedQueries` to use GET requests for cached queries (better CDN/proxy caching)
- Integrate the persisted query link into the Apollo link chain

**Backend (Go/Echo)**
- Add GET handler for `/api/graphql` endpoint to support APQ GET requests
- Server-side APQ was already enabled with `extension.AutomaticPersistedQuery`

### How APQ Works

```
Request Flow:
1. Client sends GET /api/graphql with sha256Hash in extensions
2. Server checks cache for the hash
3. Cache hit → Return response
4. Cache miss → Return PERSISTED_QUERY_NOT_FOUND
5. Client retries with POST including full query
6. Server caches query and responds
7. Subsequent requests use GET with hash only
```

## Related Issues

N/A

## Testing

1. Start the API server and Next.js dev server
2. Open browser DevTools → Network tab
3. Execute a GraphQL query (e.g., page load)
4. Verify:
   - First request: Contains `extensions.persistedQuery.sha256Hash` and uses POST (if cache miss)
   - Subsequent requests: Uses GET method with hash only in query parameters
   - Response returns successfully without 405 errors
